### PR TITLE
Ignore test files in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,16 @@
 name: CodeQL Analysis
 
+paths-ignore:
+  - tests
+  - '**/tests/**'
+  - '**/*_test.py'
+  - '**/*_tests.py'
+  - '**/test_*.py'
+  - '**/conftest.py'
+  - '**/pytest_*.py'
+  - '**/*.test.py'
+  - '**/*.spec.py'
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
- Added `paths-ignore` configuration to `.github/workflows/codeql.yml` to exclude test files from analysis.
- Paths ignored include:
  - `tests/`, `**/tests/**`, and various test file naming patterns (e.g., `*_test.py`, `*.test.py`).
- Streamlines security and quality analysis by focusing only on source files.