### PR TITLE
Chore/post api refactor cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.10', '3.12', '3.14' ]
+        python-version: [ '3.10', '3.12', '3.14' ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pre-release-test.yml
+++ b/.github/workflows/pre-release-test.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.12', '3.14']
+        python-version: ['3.10', '3.12', '3.14']
     
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.12']  # Test min and max versions
+        python-version: ['3.10', '3.14']  # Test min and max versions
     
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.12', '3.14']
+        python-version: [ '3.10', '3.12', '3.14']
 
     steps:
     - uses: actions/checkout@v3

--- a/acled/auth.py
+++ b/acled/auth.py
@@ -10,6 +10,8 @@ modern authentication (OAuth/Cookie) over legacy when possible.
 """
 
 import os
+import platform
+import tempfile
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, Tuple
 from datetime import datetime, timedelta
@@ -38,7 +40,6 @@ class AuthMethod(ABC):
         Returns:
             Modified parameters dictionary
         """
-        pass
 
     @abstractmethod
     def refresh_if_needed(self, session: requests.Session) -> None:
@@ -47,7 +48,6 @@ class AuthMethod(ABC):
         Args:
             session: The requests session to potentially update
         """
-        pass
 
     @abstractmethod
     def force_refresh(self, session: requests.Session) -> None:
@@ -59,7 +59,6 @@ class AuthMethod(ABC):
         Args:
             session: The requests session to update with new credentials
         """
-        pass
 
     @abstractmethod
     def is_authenticated(self) -> bool:
@@ -68,7 +67,6 @@ class AuthMethod(ABC):
         Returns:
             True if authenticated and valid, False otherwise
         """
-        pass
 
 
 class LegacyKeyEmailAuth(AuthMethod):
@@ -126,11 +124,9 @@ class LegacyKeyEmailAuth(AuthMethod):
 
     def refresh_if_needed(self, session: requests.Session) -> None:
         """No refresh needed for legacy authentication."""
-        pass
 
     def force_refresh(self, session: requests.Session) -> None:
         """No refresh possible for legacy authentication (static credentials)."""
-        pass
 
     def is_authenticated(self) -> bool:
         """Check if API key and email are present.
@@ -403,8 +399,6 @@ class OAuthTokenAuth(AuthMethod):
         Args:
             filepath: Path to save tokens to
         """
-        import tempfile
-        import platform
 
         token_data = {
             "access_token": self.access_token,
@@ -445,7 +439,7 @@ class OAuthTokenAuth(AuthMethod):
         Args:
             filepath: Path to load tokens from
         """
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             token_data = json.load(f)
 
         self.access_token = token_data.get("access_token")
@@ -650,22 +644,21 @@ class AuthFactory:
                 api_key=kwargs.get("api_key"),
                 email=kwargs.get("email")
             )
-        elif method == "oauth":
+        if method == "oauth":
             return OAuthTokenAuth(
                 username=kwargs.get("username") or kwargs.get("email"),
                 password=kwargs.get("password"),
                 token_file=kwargs.get("token_file")
             )
-        elif method == "cookie":
+        if method == "cookie":
             return CookieAuth(
                 username=kwargs.get("username") or kwargs.get("email"),
                 password=kwargs.get("password")
             )
-        elif method == "auto":
+        if method == "auto":
             # Auto-detect best method based on available credentials
             return AuthFactory._auto_detect(**kwargs)
-        else:
-            raise ValueError(f"Unknown authentication method: {method}")
+        raise ValueError(f"Unknown authentication method: {method}")
 
     @staticmethod
     def _auto_detect(**kwargs) -> AuthMethod:

--- a/acled/auth.py
+++ b/acled/auth.py
@@ -193,9 +193,8 @@ class OAuthTokenAuth(AuthMethod):
             try:
                 self.load_tokens(self.token_file)
                 self.log.info("Loaded existing OAuth tokens from file")
-            except Exception:
-                # File doesn't exist or is invalid, will get new tokens
-                pass
+            except (FileNotFoundError, json.JSONDecodeError, PermissionError, OSError) as e:
+                self.log.debug("Could not load tokens from %s: %s", self.token_file, e)
 
         # If we don't have valid tokens, obtain them
         if not self.is_authenticated():
@@ -357,7 +356,7 @@ class OAuthTokenAuth(AuthMethod):
         if self.refresh_token:
             try:
                 self._refresh_access_token()
-            except Exception:
+            except (ApiError, RequestException):
                 if self.username and self.password:
                     self._obtain_token()
                 else:
@@ -417,7 +416,7 @@ class OAuthTokenAuth(AuthMethod):
         dirpath = os.path.dirname(os.path.abspath(filepath))
         fd, tmp_path = tempfile.mkstemp(dir=dirpath, suffix='.tmp')
         try:
-            with os.fdopen(fd, 'w') as f:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
                 json.dump(token_data, f, indent=2)
             # Set restrictive permissions before rename (Unix)
             if platform.system() != "Windows":
@@ -686,21 +685,38 @@ class AuthFactory:
 
         # Prefer OAuth if we have username/password
         if username and password:
+            last_error: Optional[Exception] = None
             try:
                 return OAuthTokenAuth(
                     username=username,
                     password=password,
                     token_file=kwargs.get("token_file")
                 )
-            except (AcledMissingAuthError, ApiError):
-                # OAuth failed (missing creds, bad creds, or endpoint down) — try cookie
-                try:
-                    return CookieAuth(username=username, password=password)
-                except (AcledMissingAuthError, ApiError):
-                    # Cookie also failed — fall back to legacy if available
-                    if api_key and email:
-                        return LegacyKeyEmailAuth(api_key=api_key, email=email)
+            except AcledMissingAuthError:
+                pass  # Missing creds — try next method
+            except ApiError as e:
+                if getattr(e, 'status_code', None) in (401, 403):
+                    raise  # Bad credentials — don't silently try next method
+                last_error = e
+
+            try:
+                return CookieAuth(username=username, password=password)
+            except AcledMissingAuthError:
+                pass
+            except ApiError as e:
+                if getattr(e, 'status_code', None) in (401, 403):
                     raise
+                last_error = e
+
+            # Both failed — fall back to legacy if available
+            if api_key and email:
+                return LegacyKeyEmailAuth(api_key=api_key, email=email)
+            if last_error is not None:
+                raise last_error
+            raise AcledMissingAuthError(
+                "OAuth and Cookie authentication failed. "
+                "No legacy credentials available as fallback."
+            )
 
         # Use legacy if only API key/email available
         elif api_key and email:
@@ -750,29 +766,47 @@ class AuthFactory:
         # Auto-detect based on available environment variables
         # Priority: OAuth/Cookie > Legacy
         if username and password:
-            # Try OAuth first, fall back to cookie only if credentials are missing
-            # (not if the auth endpoint is down or credentials are invalid)
+            # Try OAuth first, fall back to cookie only if the auth method
+            # is unavailable (not if credentials are invalid)
+            last_error: Optional[Exception] = None
             try:
                 return AuthFactory.create_auth(
                     "oauth",
                     username=username,
                     password=password
                 )
-            except (AcledMissingAuthError, ApiError):
-                try:
-                    return AuthFactory.create_auth(
-                        "cookie",
-                        username=username,
-                        password=password
-                    )
-                except (AcledMissingAuthError, ApiError):
-                    if api_key and email:
-                        return AuthFactory.create_auth(
-                            "legacy",
-                            api_key=api_key,
-                            email=email
-                        )
+            except AcledMissingAuthError:
+                pass
+            except ApiError as e:
+                if getattr(e, 'status_code', None) in (401, 403):
                     raise
+                last_error = e
+
+            try:
+                return AuthFactory.create_auth(
+                    "cookie",
+                    username=username,
+                    password=password
+                )
+            except AcledMissingAuthError:
+                pass
+            except ApiError as e:
+                if getattr(e, 'status_code', None) in (401, 403):
+                    raise
+                last_error = e
+
+            if api_key and email:
+                return AuthFactory.create_auth(
+                    "legacy",
+                    api_key=api_key,
+                    email=email
+                )
+            if last_error is not None:
+                raise last_error
+            raise AcledMissingAuthError(
+                "OAuth and Cookie authentication failed from environment. "
+                "No legacy credentials available as fallback."
+            )
 
         elif api_key and email:
             return AuthFactory.create_auth(

--- a/acled/cli/commands/auth.py
+++ b/acled/cli/commands/auth.py
@@ -2,12 +2,11 @@
 
 import argparse
 import getpass
-import sys
 from typing import Optional
 
-from acled.cli.utils.auth import CredentialManager, AuthenticationError
+from acled.auth import AuthFactory, CookieAuth, OAuthTokenAuth
+from acled.cli.utils.auth import CredentialManager
 from acled.clients import AcledClient
-from acled.auth import AuthFactory, OAuthTokenAuth
 
 
 class AuthCommand:
@@ -112,15 +111,14 @@ Examples:
 
         if args.auth_command == 'login':
             return self._handle_login(args)
-        elif args.auth_command == 'logout':
+        if args.auth_command == 'logout':
             return self._handle_logout(args)
-        elif args.auth_command == 'status':
+        if args.auth_command == 'status':
             return self._handle_status(args)
-        elif args.auth_command == 'test':
+        if args.auth_command == 'test':
             return self._handle_test(args)
-        else:
-            print(f"Error: Unknown auth command: {args.auth_command}")
-            return 1
+        print(f"Error: Unknown auth command: {args.auth_command}")
+        return 1
 
     def _handle_login(self, args: argparse.Namespace) -> int:
         """Handle login command."""
@@ -132,14 +130,14 @@ Examples:
                 return 1
 
             auth_method = args.method
-            
+
             # For auto mode, detect based on provided credentials
             if auth_method == 'auto':
                 # Check what credentials we're getting
                 has_username = bool(args.username or args.email)
                 has_password = bool(args.password)
                 has_api_key = bool(args.api_key)
-                
+
                 if has_username or has_password:
                     # Modern auth - will auto-select OAuth or Cookie
                     auth_method = 'oauth'  # Factory will handle fallback to cookie
@@ -155,7 +153,7 @@ Examples:
                         auth_method = 'legacy'
                     else:
                         auth_method = 'oauth'
-            
+
             if auth_method == 'legacy':
                 # Get legacy credentials
                 api_key = args.api_key
@@ -186,25 +184,25 @@ Examples:
                     email=email.strip(),
                     auth_method='legacy'
                 )
-                
+
             else:  # oauth or cookie
                 # Handle modern authentication (OAuth/Cookie)
                 username = args.username or args.email  # Accept either
                 password = args.password
-                
+
                 # Prompt for missing credentials
                 if not username:
                     username = input("ACLED Username/Email: ")
                     if not username.strip():
                         print("Error: Username/email is required for authentication.")
                         return 1
-                
+
                 if not password:
                     password = getpass.getpass("ACLED Password: ")
                     if not password.strip():
                         print("Error: Password is required for authentication.")
                         return 1
-                
+
                 # Validate credentials
                 print(f"Validating {auth_method} credentials...")
                 if auth_method == 'cookie':
@@ -238,7 +236,7 @@ Examples:
             print(f"Error storing credentials: {e}")
             return 1
 
-    def _handle_logout(self, args: argparse.Namespace) -> int:
+    def _handle_logout(self, _args: argparse.Namespace) -> int:
         """Handle logout command."""
         try:
             if not self.credential_manager.has_stored_credentials():
@@ -253,7 +251,7 @@ Examples:
             print(f"Error clearing credentials: {e}")
             return 1
 
-    def _handle_status(self, args: argparse.Namespace) -> int:
+    def _handle_status(self, _args: argparse.Namespace) -> int:
         """Handle status command."""
         try:
             if self.credential_manager.has_stored_credentials():
@@ -270,7 +268,7 @@ Examples:
             print(f"Error checking status: {e}")
             return 1
 
-    def _handle_test(self, args: argparse.Namespace) -> int:
+    def _handle_test(self, _args: argparse.Namespace) -> int:
         """Handle test command."""
         try:
             if not self.credential_manager.has_stored_credentials():
@@ -288,14 +286,14 @@ Examples:
                     print("✓ Credentials are valid.")
                     return 0
             else:  # modern auth (oauth/cookie)
-                # Create auth instance from stored credentials  
+                # Create auth instance from stored credentials
                 try:
                     username = creds.get('username') or creds.get('email')
                     password = creds.get('password')
                     if not username or not password:
                         print("✗ Incomplete credentials stored.")
                         return 1
-                    
+
                     # Try with stored method first
                     try:
                         auth = AuthFactory.create_auth(
@@ -320,7 +318,7 @@ Examples:
                         return 0
                 except Exception:
                     pass
-            
+
             print("✗ Stored credentials are invalid.")
             print("Use 'acled auth login --force' to update them.")
             return 1
@@ -341,7 +339,7 @@ Examples:
 
         except Exception:
             return False
-    
+
     def _validate_modern_credentials(self, username: str, password: str) -> Optional[str]:
         """Validate modern credentials by testing authentication.
 
@@ -360,18 +358,16 @@ Examples:
         except Exception:
             # If OAuth fails, try cookie
             try:
-                from acled.auth import CookieAuth
                 auth = CookieAuth(username=username, password=password)
                 client = AcledClient(auth_method=auth)
                 client.get_data(limit=1)
                 return 'cookie'
             except Exception:
                 return None
-    
+
     def _validate_cookie_credentials(self, username: str, password: str) -> bool:
         """Validate cookie credentials by testing authentication."""
         try:
-            from acled.auth import CookieAuth
             auth = CookieAuth(username=username, password=password)
             client = AcledClient(auth_method=auth)
             client.get_data(limit=1)

--- a/acled/cli/commands/auth.py
+++ b/acled/cli/commands/auth.py
@@ -7,6 +7,7 @@ from typing import Optional
 from acled.auth import AuthFactory, CookieAuth, OAuthTokenAuth
 from acled.cli.utils.auth import CredentialManager
 from acled.clients import AcledClient
+from acled.exceptions import ApiError, AcledMissingAuthError
 
 
 class AuthCommand:
@@ -305,7 +306,7 @@ Examples:
                         client.get_data(limit=1)
                         print(f"✓ {auth_method.capitalize()} credentials are valid.")
                         return 0
-                    except Exception:
+                    except (ApiError, AcledMissingAuthError):
                         # Try auto-detect as fallback
                         auth = AuthFactory.create_auth(
                             'auto',
@@ -316,7 +317,7 @@ Examples:
                         client.get_data(limit=1)
                         print("✓ Credentials are valid.")
                         return 0
-                except Exception:
+                except (ApiError, AcledMissingAuthError):
                     pass
 
             print("✗ Stored credentials are invalid.")
@@ -330,14 +331,10 @@ Examples:
     def _validate_legacy_credentials(self, api_key: str, email: str) -> bool:
         """Validate legacy credentials by making a test API call."""
         try:
-            # Create a client with the provided credentials
             client = AcledClient(auth_method="legacy", api_key=api_key, email=email)
-
-            # Make a minimal test request (limit=1 to minimize data usage)
             client.get_data(limit=1)
             return True
-
-        except Exception:
+        except (ApiError, AcledMissingAuthError):
             return False
 
     def _validate_modern_credentials(self, username: str, password: str) -> Optional[str]:
@@ -347,22 +344,19 @@ Examples:
             The auth method that succeeded ('oauth' or 'cookie'), or None on failure.
         """
         try:
-            # Try OAuth first, with token caching
             token_file = self.credential_manager.get_token_file()
             auth = OAuthTokenAuth(username=username, password=password, token_file=token_file)
             client = AcledClient(auth_method=auth)
             client.get_data(limit=1)
-            # Save tokens now that we know they work
             auth.save_tokens(token_file)
             return 'oauth'
-        except Exception:
-            # If OAuth fails, try cookie
+        except (ApiError, AcledMissingAuthError):
             try:
                 auth = CookieAuth(username=username, password=password)
                 client = AcledClient(auth_method=auth)
                 client.get_data(limit=1)
                 return 'cookie'
-            except Exception:
+            except (ApiError, AcledMissingAuthError):
                 return None
 
     def _validate_cookie_credentials(self, username: str, password: str) -> bool:
@@ -372,5 +366,5 @@ Examples:
             client = AcledClient(auth_method=auth)
             client.get_data(limit=1)
             return True
-        except Exception:
+        except (ApiError, AcledMissingAuthError):
             return False

--- a/acled/cli/commands/data.py
+++ b/acled/cli/commands/data.py
@@ -1,7 +1,6 @@
 """Data command for retrieving ACLED events."""
 
 import argparse
-from typing import Optional
 
 from acled.cli.commands.base import BaseCommand
 

--- a/acled/cli/formatters/summary.py
+++ b/acled/cli/formatters/summary.py
@@ -14,13 +14,12 @@ class SummaryFormatter(BaseFormatter):
             count = len(data)
             if count == 0:
                 return "No items found"
-            elif count == 1:
+            if count == 1:
                 return f"1 item found:\n{self._format_single_item(data[0])}"
-            else:
-                return f"{count} items found\n" + "\n".join(
-                    f"Item {i+1}: {self._format_single_item(item)}"
-                    for i, item in enumerate(data[:5])  # Show first 5 items
-                ) + (f"\n... and {count - 5} more items" if count > 5 else "")
+            return f"{count} items found\n" + "\n".join(
+                f"Item {i+1}: {self._format_single_item(item)}"
+                for i, item in enumerate(data[:5])  # Show first 5 items
+            ) + (f"\n... and {count - 5} more items" if count > 5 else "")
 
         # Handle non-list data
         if not data:
@@ -41,9 +40,8 @@ class SummaryFormatter(BaseFormatter):
 
             if summary_parts:
                 return ", ".join(summary_parts)
-            else:
-                # Fallback to first few fields
-                items_to_show = list(item.items())[:3]
-                return ", ".join(f"{k}: {v}" for k, v in items_to_show)
+            # Fallback to first few fields
+            items_to_show = list(item.items())[:3]
+            return ", ".join(f"{k}: {v}" for k, v in items_to_show)
 
         return str(item)

--- a/acled/cli/utils/auth.py
+++ b/acled/cli/utils/auth.py
@@ -1,11 +1,12 @@
 """Secure credential storage utilities."""
 
+import getpass
 import json
 import logging
 import os
 import platform
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 try:
     import keyring
@@ -95,8 +96,7 @@ class CredentialManager:
         """Retrieve stored credentials."""
         if self.use_keyring:
             return self._get_from_keyring()
-        else:
-            return self._get_from_encrypted_file()
+        return self._get_from_encrypted_file()
 
     def has_stored_credentials(self) -> bool:
         """Check if credentials are stored."""
@@ -105,8 +105,7 @@ class CredentialManager:
             auth_method = creds.get('auth_method', 'legacy')
             if auth_method == 'legacy':
                 return bool(creds.get('api_key') and creds.get('email'))
-            else:  # oauth
-                return bool(creds.get('username') and creds.get('password'))
+            return bool(creds.get('username') and creds.get('password'))
         except Exception:
             return False
 
@@ -239,7 +238,6 @@ class CredentialManager:
     def _get_machine_identifier(self) -> str:
         """Get a machine-specific identifier for encryption."""
         # Use platform and user info as basis for machine-specific key
-        import getpass
         machine_id = f"{platform.node()}-{platform.system()}-{getpass.getuser()}"
         return machine_id[:32].ljust(32, '0')  # Ensure consistent length
 

--- a/acled/cli/utils/auth.py
+++ b/acled/cli/utils/auth.py
@@ -69,7 +69,7 @@ class CredentialManager:
         try:
             keyring.get_keyring()
             return True
-        except Exception:
+        except (RuntimeError, AttributeError, ImportError):
             return False
 
     def store_credentials(
@@ -106,7 +106,7 @@ class CredentialManager:
             if auth_method == 'legacy':
                 return bool(creds.get('api_key') and creds.get('email'))
             return bool(creds.get('username') and creds.get('password'))
-        except Exception:
+        except (AuthenticationError, OSError, RuntimeError):
             return False
 
     def get_stored_email(self) -> Optional[str]:
@@ -114,7 +114,7 @@ class CredentialManager:
         try:
             creds = self.get_credentials()
             return creds.get('email') or creds.get('username')
-        except Exception:
+        except (AuthenticationError, OSError, RuntimeError):
             return None
 
     def get_token_file(self) -> str:

--- a/acled/cli/utils/config.py
+++ b/acled/cli/utils/config.py
@@ -120,15 +120,14 @@ class CLIConfig:
                         password=creds.get('password'),
                         token_file=credential_manager.get_token_file()
                     )
-                elif auth_method == 'cookie':
+                if auth_method == 'cookie':
                     return AuthFactory.create_auth(
                         'cookie',
                         username=creds.get('username'),
                         password=creds.get('password')
                     )
-                else:
-                    # For legacy, we'll use api_key/email properties
-                    return None
+                # For legacy, we'll use api_key/email properties
+                return None
         except AuthenticationError:
             pass
 

--- a/acled/clients/acled_data_client.py
+++ b/acled/clients/acled_data_client.py
@@ -14,7 +14,7 @@ from datetime import datetime, date, timezone
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import AcledEvent
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError, NetworkError, TimeoutError, RateLimitError, RetryError, ServerError, ClientError
 
 
@@ -195,7 +195,7 @@ class AcledDataClient(BaseHttpClient):
             self.log.error("API Error: %s", error_message)
             raise ApiError(f"API Error: {error_message}")
 
-        except (NetworkError, TimeoutError, RateLimitError, ServerError, ClientError, RetryError) as e:
+        except (NetworkError, TimeoutError, RateLimitError, ServerError, ClientError, RetryError):
             # These exceptions are already logged in BaseHttpClient
             raise
         except Exception as e:

--- a/acled/clients/actor_client.py
+++ b/acled/clients/actor_client.py
@@ -10,7 +10,7 @@ from datetime import datetime, date
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import Actor
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError, NetworkError, TimeoutError, RateLimitError, RetryError, ServerError, ClientError
 
 
@@ -104,7 +104,7 @@ class ActorClient(BaseHttpClient):
             self.log.error("API Error: %s", error_message)
             raise ApiError(f"API Error: {error_message}")
 
-        except (NetworkError, TimeoutError, RateLimitError, ServerError, ClientError, RetryError) as e:
+        except (NetworkError, TimeoutError, RateLimitError, ServerError, ClientError, RetryError):
             # These exceptions are already logged in BaseHttpClient
             raise
         except Exception as e:

--- a/acled/clients/actor_type_client.py
+++ b/acled/clients/actor_type_client.py
@@ -6,12 +6,13 @@ It allows filtering by various criteria such as actor type ID, name, and event d
 """
 
 from typing import Any, Dict, List, Optional, Union
-import requests
 from datetime import datetime, date
+
+import requests
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import ActorType
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError
 
 class ActorTypeClient(BaseHttpClient):

--- a/acled/clients/base_http_client.py
+++ b/acled/clients/base_http_client.py
@@ -17,11 +17,12 @@ import requests
 from requests.exceptions import RequestException, Timeout, ConnectionError, HTTPError
 
 from acled.exceptions import (
-    ApiError, NetworkError, TimeoutError,
+    ApiError, AcledMissingAuthError, NetworkError, TimeoutError,
     RetryError, RateLimitError, ServerError, ClientError
 )
 from acled.log import AcledLogger
 from acled.auth import AuthMethod, AuthFactory, LegacyKeyEmailAuth
+from acled.models.enums import ResponseFormat
 
 T = TypeVar('T')
 
@@ -84,12 +85,13 @@ class BaseHttpClient:
     RETRY_STATUS_CODES = [429, 500, 502, 503, 504]  # Rate limit and server errors
     DEFAULT_TIMEOUT = int(environ.get("ACLED_REQUEST_TIMEOUT", "30"))  # seconds
 
-    def __init__(self, auth_method: Optional[Union[str, AuthMethod]] = None, _legacy_email: Optional[str] = None, **auth_kwargs):
+    def __init__(self, auth_method: Optional[Union[str, AuthMethod]] = None, _legacy_email: Optional[str] = None, *, session: Optional[requests.Session] = None, **auth_kwargs):
         """Initialize the base HTTP client with authentication.
 
         Args:
             auth_method: Authentication method (AuthMethod instance, method name, or None for auto)
             _legacy_email: Deprecated positional email arg for backward compatibility
+            session: Optional shared requests.Session (if not provided, a new one is created)
             **auth_kwargs: Authentication parameters (username, password, api_key, email, etc.)
         """
         self.log = AcledLogger().get_logger()
@@ -116,8 +118,18 @@ class BaseHttpClient:
             self.api_key = None
             self.email = None
 
-        self.session = requests.Session()
-        self.session.headers.update({'Content-Type': 'application/json'})
+        if session is not None:
+            self.session = session
+            self._owns_session = False
+        else:
+            self.session = requests.Session()
+            self.session.headers.update({'Content-Type': 'application/json'})
+            self._owns_session = True
+
+    def close(self) -> None:
+        """Close the HTTP session if this client owns it."""
+        if self._owns_session:
+            self.session.close()
 
     def process_params(self, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
@@ -187,7 +199,7 @@ class BaseHttpClient:
         # Refresh authentication if needed (non-fatal — will retry via 401 path)
         try:
             self.auth.refresh_if_needed(self.session)
-        except Exception as e:
+        except (ApiError, RequestException, AcledMissingAuthError) as e:
             self.log.warning("Pre-request auth refresh failed: %s", str(e))
 
         processed_params = self.process_params(params) if method.lower() == 'get' else None
@@ -248,7 +260,7 @@ class BaseHttpClient:
                         self.auth.force_refresh(self.session)
                         processed_params = self.process_params(params) if method.lower() == 'get' else None
                         processed_data = self.process_params(data) if method.lower() == 'post' else None
-                    except Exception as e:
+                    except (ApiError, RequestException, AcledMissingAuthError) as e:
                         self.log.warning("Auth refresh failed: %s", str(e))
                         last_exception = ApiError(f"Auth refresh failed: {str(e)}")
                     auth_refreshed = True
@@ -274,11 +286,11 @@ class BaseHttpClient:
                 status_code = getattr(getattr(e, "response", None), "status_code", None)
                 self.log.error("HTTP error: %s (status code: %s)", str(e), status_code)
                 if status_code and 500 <= status_code < 600:
-                    last_exception = ServerError(f"Server error ({status_code}): {str(e)}")
+                    last_exception = ServerError(f"Server error ({status_code}): {str(e)}", status_code=status_code)
                 elif status_code and 400 <= status_code < 500:
-                    raise ClientError(f"Client error ({status_code}): {str(e)}") from e
+                    raise ClientError(f"Client error ({status_code}): {str(e)}", status_code=status_code) from e
                 else:
-                    raise ApiError(f"HTTP error ({status_code}): {str(e)}") from e
+                    raise ApiError(f"HTTP error ({status_code}): {str(e)}", status_code=status_code) from e
             except RequestException as e:
                 self.log.error("Request error: %s", str(e))
                 last_exception = ApiError(f"Request error: {str(e)}")
@@ -293,6 +305,28 @@ class BaseHttpClient:
             raise RetryError(f"Max retries ({self.MAX_RETRIES}) exceeded. Last error: {str(last_exception)}")
         raise RetryError(f"Max retries ({self.MAX_RETRIES}) exceeded.")
 
+    @staticmethod
+    def _validate_response_format(params: Optional[Dict[str, Any]]) -> None:
+        """Validate that the response format is JSON (the only supported format).
+
+        Raises:
+            ValueError: If a non-JSON response format is requested
+        """
+        if params is None:
+            return
+        fmt = params.get('response_format')
+        if fmt is None:
+            return
+        if isinstance(fmt, ResponseFormat):
+            fmt_val = fmt.value
+        else:
+            fmt_val = str(fmt).lower()
+        if fmt_val != 'json':
+            raise ValueError(
+                f"Unsupported response_format '{fmt}'. "
+                "Only JSON format is supported."
+            )
+
     def _get(
             self, endpoint: str, params: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
@@ -306,6 +340,7 @@ class BaseHttpClient:
         Returns:
             API response as dictionary
         """
+        self._validate_response_format(params)
         return self._request_with_retries('get', endpoint, params=params)
 
     def _post(

--- a/acled/clients/base_http_client.py
+++ b/acled/clients/base_http_client.py
@@ -11,18 +11,17 @@ from os import environ
 import time
 import random
 from datetime import date, datetime
+import warnings
 
 import requests
 from requests.exceptions import RequestException, Timeout, ConnectionError, HTTPError
 
 from acled.exceptions import (
-    AcledMissingAuthError, ApiError, NetworkError, TimeoutError,
+    ApiError, NetworkError, TimeoutError,
     RetryError, RateLimitError, ServerError, ClientError
 )
 from acled.log import AcledLogger
 from acled.auth import AuthMethod, AuthFactory, LegacyKeyEmailAuth
-
-import warnings
 
 T = TypeVar('T')
 
@@ -74,7 +73,7 @@ def _handle_legacy_positional_args(auth_method, auth_kwargs):
     return auth_method, auth_kwargs
 
 
-class BaseHttpClient(object):
+class BaseHttpClient:
     """
     A base HTTP client that provides basic GET and POST request functionality.
     """
@@ -108,7 +107,7 @@ class BaseHttpClient(object):
             self.auth = AuthFactory.create_auth("auto", **auth_kwargs)
         else:
             self.auth = AuthFactory.from_environment()
-        
+
         # Legacy attributes for backward compatibility
         if isinstance(self.auth, LegacyKeyEmailAuth):
             self.api_key = self.auth.api_key
@@ -116,7 +115,7 @@ class BaseHttpClient(object):
         else:
             self.api_key = None
             self.email = None
-        
+
         self.session = requests.Session()
         self.session.headers.update({'Content-Type': 'application/json'})
 
@@ -184,13 +183,13 @@ class BaseHttpClient(object):
         """
         url = f"{self.BASE_URL}{endpoint}"
         timeout = timeout or self.DEFAULT_TIMEOUT
-        
+
         # Refresh authentication if needed (non-fatal — will retry via 401 path)
         try:
             self.auth.refresh_if_needed(self.session)
         except Exception as e:
             self.log.warning("Pre-request auth refresh failed: %s", str(e))
-        
+
         processed_params = self.process_params(params) if method.lower() == 'get' else None
         processed_data = self.process_params(data) if method.lower() == 'post' else None
 

--- a/acled/clients/cast_client.py
+++ b/acled/clients/cast_client.py
@@ -12,7 +12,7 @@ import requests
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import CastForecast
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError
 
 

--- a/acled/clients/client.py
+++ b/acled/clients/client.py
@@ -9,6 +9,8 @@ This simplifies usage and provides a consistent entry point for all API interact
 from typing import Optional, Any, Dict, List, Union
 from datetime import date
 
+import requests
+
 from acled.clients.acled_data_client import AcledDataClient
 from acled.clients.actor_client import ActorClient
 from acled.clients.actor_type_client import ActorTypeClient
@@ -93,13 +95,27 @@ class AcledClient:
         else:
             auth = AuthFactory.from_environment()
 
-        self._acled_data_client = AcledDataClient(auth_method=auth)
-        self._actor_client = ActorClient(auth_method=auth)
-        self._cast_client = CastClient(auth_method=auth)
-        self._country_client = CountryClient(auth_method=auth)
-        self._deleted_client = DeletedClient(auth_method=auth)
-        self._region_client = RegionClient(auth_method=auth)
-        self._actor_type_client = ActorTypeClient(auth_method=auth)
+        self._session = requests.Session()
+        self._session.headers.update({'Content-Type': 'application/json'})
+
+        self._acled_data_client = AcledDataClient(auth_method=auth, session=self._session)
+        self._actor_client = ActorClient(auth_method=auth, session=self._session)
+        self._cast_client = CastClient(auth_method=auth, session=self._session)
+        self._country_client = CountryClient(auth_method=auth, session=self._session)
+        self._deleted_client = DeletedClient(auth_method=auth, session=self._session)
+        self._region_client = RegionClient(auth_method=auth, session=self._session)
+        self._actor_type_client = ActorTypeClient(auth_method=auth, session=self._session)
+
+    def close(self) -> None:
+        """Close the shared HTTP session and release resources."""
+        self._session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
 
 
     def get_data(

--- a/acled/clients/client.py
+++ b/acled/clients/client.py
@@ -7,7 +7,7 @@ This simplifies usage and provides a consistent entry point for all API interact
 """
 
 from typing import Optional, Any, Dict, List, Union
-from datetime import datetime, date
+from datetime import date
 
 from acled.clients.acled_data_client import AcledDataClient
 from acled.clients.actor_client import ActorClient
@@ -17,7 +17,7 @@ from acled.clients.country_client import CountryClient
 from acled.clients.deleted_client import DeletedClient
 from acled.clients.region_client import RegionClient
 from acled.models import AcledEvent, Actor, ActorType, CastForecast, DeletedEvent, Country, Region
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.auth import AuthMethod, AuthFactory
 from acled.clients.base_http_client import _validate_auth_method_arg, _handle_legacy_positional_args
 

--- a/acled/clients/country_client.py
+++ b/acled/clients/country_client.py
@@ -11,7 +11,7 @@ import requests
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import Country
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError
 
 class CountryClient(BaseHttpClient):

--- a/acled/clients/deleted_client.py
+++ b/acled/clients/deleted_client.py
@@ -11,7 +11,7 @@ import requests
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import DeletedEvent
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError
 
 

--- a/acled/clients/region_client.py
+++ b/acled/clients/region_client.py
@@ -12,7 +12,7 @@ import requests
 
 from acled.clients.base_http_client import BaseHttpClient
 from acled.models import Region
-from acled.models.enums import ResponseFormat, ExportType
+from acled.models.enums import ResponseFormat
 from acled.exceptions import ApiError
 
 class RegionClient(BaseHttpClient):

--- a/acled/exceptions.py
+++ b/acled/exceptions.py
@@ -11,6 +11,10 @@ class ApiError(Exception):
     Exception raised for errors returned by the API.
     """
 
+    def __init__(self, message: str = "", status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
 
 class AcledMissingAuthError(ValueError):
     """

--- a/acled/log.py
+++ b/acled/log.py
@@ -7,6 +7,7 @@ with configurable log levels and a consistent log format.
 import logging
 import os
 import sys
+import threading
 from logging import Logger
 
 
@@ -18,12 +19,15 @@ class AcledLogger:
     be configured via the 'LOG_LEVEL' environment variable.
     """
     _instance = None
+    _lock = threading.Lock()
     logger: Logger
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
-            cls._instance = super().__new__(cls, *args, **kwargs)
-            cls._instance._initialize()
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls, *args, **kwargs)
+                    cls._instance._initialize()
         return cls._instance
 
     def _initialize(self):
@@ -31,13 +35,14 @@ class AcledLogger:
         self.logger = logging.getLogger("acled_logger")
         self.logger.setLevel(getattr(logging, log_level, logging.WARNING))
 
-        handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter(
-            '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - '
-            'Thread:%(threadName)s(Process:%(processName)s) - %(message)s'
-        )
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler(sys.stdout)
+            formatter = logging.Formatter(
+                '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - '
+                'Thread:%(threadName)s(Process:%(processName)s) - %(message)s'
+            )
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
 
     def get_logger(self) -> Logger:
         """Returns the configured logger instance.

--- a/acled/models/data_models.py
+++ b/acled/models/data_models.py
@@ -5,7 +5,7 @@ returned by the ACLED API, including events, actors, countries, regions, and
 actor types.
 """
 
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Union
 import datetime
 
 
@@ -66,7 +66,7 @@ class Country(TypedDict, total=False):
     including its name, ISO codes, and event statistics.
     """
     country: str
-    iso: int
+    iso: Union[int, str]
     iso3: str
     first_event_date: datetime.date
     last_event_date: datetime.date
@@ -94,16 +94,16 @@ class CastForecast(TypedDict, total=False):
     country: str
     admin1: str
     month: str
-    year: int
-    total_forecast: int
-    battles_forecast: int
-    erv_forecast: int
-    vac_forecast: int
-    total_observed: int
-    battles_observed: int
-    erv_observed: int
-    vac_observed: int
-    timestamp: int
+    year: Union[int, str]
+    total_forecast: Union[int, str]
+    battles_forecast: Union[int, str]
+    erv_forecast: Union[int, str]
+    vac_forecast: Union[int, str]
+    total_observed: Union[int, str]
+    battles_observed: Union[int, str]
+    erv_observed: Union[int, str]
+    vac_observed: Union[int, str]
+    timestamp: Union[int, str]
 
 
 class DeletedEvent(TypedDict, total=False):
@@ -113,7 +113,7 @@ class DeletedEvent(TypedDict, total=False):
     along with the timestamp of its deletion.
     """
     event_id_cnty: str
-    deleted_timestamp: int
+    deleted_timestamp: Union[int, str]
 
 
 class ActorType(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = {text = "GPL 3"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["acled", "api", "conflict", "data", "political violence", "research"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ setup(
     ],
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
 )

--- a/tests/cli/commands/test_auth.py
+++ b/tests/cli/commands/test_auth.py
@@ -375,12 +375,13 @@ class TestAuthCommand(unittest.TestCase):
         
         # Mock client that raises exception
         mock_client = Mock()
-        mock_client.get_data.side_effect = Exception("Invalid credentials")
+        from acled.exceptions import ApiError
+        mock_client.get_data.side_effect = ApiError("Invalid credentials")
         mock_client_class.return_value = mock_client
-        
+
         with patch('acled.cli.commands.auth.CredentialManager'):
             command = AuthCommand(self.mock_config)
-        
+
         result = command._validate_legacy_credentials('invalid_key', 'test@example.com')
         
         self.assertFalse(result)
@@ -393,7 +394,8 @@ class TestAuthCommand(unittest.TestCase):
         from acled.cli.commands.auth import AuthCommand
 
         # OAuth constructor raises
-        mock_oauth_class.side_effect = Exception("OAuth failed")
+        from acled.exceptions import ApiError
+        mock_oauth_class.side_effect = ApiError("OAuth failed")
 
         # Cookie succeeds
         mock_client = Mock()
@@ -403,7 +405,7 @@ class TestAuthCommand(unittest.TestCase):
         with patch('acled.cli.commands.auth.CredentialManager'):
             command = AuthCommand(self.mock_config)
 
-        with patch('acled.auth.CookieAuth') as mock_cookie_class:
+        with patch('acled.cli.commands.auth.CookieAuth') as mock_cookie_class:
             mock_cookie_auth = Mock()
             mock_cookie_class.return_value = mock_cookie_auth
             result = command._validate_modern_credentials('user', 'pass')
@@ -436,7 +438,8 @@ class TestAuthCommand(unittest.TestCase):
         """Test that login stores auth_method='cookie' when only cookie succeeds."""
         from acled.cli.commands.auth import AuthCommand
 
-        mock_oauth_class.side_effect = Exception("OAuth failed")
+        from acled.exceptions import ApiError
+        mock_oauth_class.side_effect = ApiError("OAuth failed")
 
         mock_client = Mock()
         mock_client.get_data.return_value = [{"test": "data"}]
@@ -456,7 +459,7 @@ class TestAuthCommand(unittest.TestCase):
         args.api_key = None
         args.force = False
 
-        with patch('acled.auth.CookieAuth') as mock_cookie_class:
+        with patch('acled.cli.commands.auth.CookieAuth') as mock_cookie_class:
             mock_cookie_class.return_value = Mock()
             with patch('builtins.print'):
                 result = command._handle_login(args)

--- a/tests/cli/utils/test_auth.py
+++ b/tests/cli/utils/test_auth.py
@@ -76,7 +76,7 @@ class TestCredentialManager(unittest.TestCase):
         from acled.cli.utils.auth import CredentialManager
         
         # Mock keyring as failing
-        mock_keyring.get_keyring.side_effect = Exception("Keyring not available")
+        mock_keyring.get_keyring.side_effect = RuntimeError("Keyring not available")
         
         manager = CredentialManager()
         self.assertFalse(manager.use_keyring)


### PR DESCRIPTION
This branch tidies up the codebase after the recent API refactor, with a few substantive improvements mixed in:

- Shared session management: AcledClient now creates a single requests.Session shared across all sub-clients instead of each one creating its own. The client supports context manager usage (with AcledClient() as client:).
- Smarter auth fallback: The AuthFactory auto-detection logic no longer silently swallows 401/403 errors when falling back between OAuth, cookie, and legacy auth. Bad credentials now fail fast instead of cascading into the wrong auth method.
- ApiError gains status_code: Exception instances now carry the HTTP status code, enabling callers (and the auth fallback logic above) to make decisions based on it.
- Thread-safe logger singleton: AcledLogger uses double-checked locking and avoids adding duplicate handlers.                                                                                                                                                                                                    
- Minimum Python bumped to 3.10: Drops 3.8/3.9 support.
- Data model types relaxed: Several int fields in CastForecast, Country, and DeletedEvent are now Union[int, str] to match what the API actually returns.
- Response format validation: _get now rejects non-JSON format requests upfront.
- General cleanup: Removed unused imports (ExportType from client modules), replaced bare except Exception with specific exception types, removed no-op pass statements from abstract methods, added explicit encoding='utf-8' to file I/O.